### PR TITLE
Remove unneeded semicolons at the end of mappings in examples

### DIFF
--- a/source-map.bs
+++ b/source-map.bs
@@ -146,7 +146,7 @@ following structure:
   "sources": ["foo.js", "bar.js"],
   "sourcesContent": [null, null],
   "names": ["src", "maps", "are", "fun"],
-  "mappings": "A,AAAB;;ABCDE;"
+  "mappings": "A,AAAB;;ABCDE"
 }
 ```
 
@@ -282,7 +282,7 @@ an alternate representation of a map is supported:
         "file": "section.js",
         "sources": ["foo.js", "bar.js"],
         "names": ["src", "maps", "are", "fun"],
-        "mappings": "AAAA,E;;ABCDE;"
+        "mappings": "AAAA,E;;ABCDE"
       }
     },
     {
@@ -292,7 +292,7 @@ an alternate representation of a map is supported:
         "file": "another_section.js",
         "sources": ["more.js"],
         "names": ["more", "is", "better"],
-        "mappings": "AAAA,E;AACA,C;ABCDE;"
+        "mappings": "AAAA,E;AACA,C;ABCDE"
       }
     }
   ]


### PR DESCRIPTION
Otherwise, a spec reader could think they are obligatory.