### PR TITLE
Check IPR for commits in `HEAD`, without hard-coding `main`

### DIFF
--- a/.github/workflows/ipr.yml
+++ b/.github/workflows/ipr.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
-      - run: node scripts/ipr-check.js tc39/source-map-spec main
+      - run: node scripts/ipr-check.js tc39/source-map-spec HEAD
         env:
           GH_TOKEN: ${{ secrets.GH_IPR_TOKEN }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}


### PR DESCRIPTION
So that, when running in PRs `` `git rev-parse --short ${branch}` `` gets the latest commit SHA. The GH api URL ends up being https://api.github.com/repos/tc39/source-map-spec/commits?anon=1&per_page=1&page=1&sha=30971dc, which works even if the commit is not in this repo yet but in a fork (you can open for example that link, that points to a commit in https://github.com/tc39/source-map-spec/pull/17).

This is equivalent to what ecma262 does in https://github.com/tc39/ecma262/blob/9abd594ecc5d6ed5317bc276b1854d3a1f9763ff/package.json#L7.