### PR TITLE
Add statement about possibility of source map rejecting in case of an invalid version field

### DIFF
--- a/source-map.bs
+++ b/source-map.bs
@@ -167,8 +167,8 @@ Note: The previous specification suggested an order to the keys in this file, bu
 for practical reasons, the order cannot be defined in many JSON generators and
 has never been enforced.
 
-<dfn><code>version</code></dfn> is the version field which is always the number
-`3` as an integer. A source map may be rejected in case of a value different from `3`.
+<dfn><code>version</code></dfn> is the version field which must always be the number
+`3` as an integer. The source map may be rejected in case of a value different from `3`.
 
 <dfn><code>file</code></dfn> an optional name of the generated code
 that this source map is associated with.  <mark>It's not specified if this can

--- a/source-map.bs
+++ b/source-map.bs
@@ -168,7 +168,7 @@ for practical reasons, the order cannot be defined in many JSON generators and
 has never been enforced.
 
 <dfn><code>version</code></dfn> is the version field which is always the number
-`3` as an integer. Source map can be rejected in case of a value different from `3`.
+`3` as an integer. A source map may be rejected in case of a value different from `3`.
 
 <dfn><code>file</code></dfn> an optional name of the generated code
 that this source map is associated with.  <mark>It's not specified if this can

--- a/source-map.bs
+++ b/source-map.bs
@@ -168,7 +168,7 @@ for practical reasons, the order cannot be defined in many JSON generators and
 has never been enforced.
 
 <dfn><code>version</code></dfn> is the version field which is always the number
-`3` as an integer.
+`3` as an integer. Source map can be rejected in case of a value different from `3`.
 
 <dfn><code>file</code></dfn> an optional name of the generated code
 that this source map is associated with.  <mark>It's not specified if this can


### PR DESCRIPTION
I'm not quite sure about `can be rejected` instead of `should be rejected,` but I feel there should be freedom for choosing such behavior for tooling, but it is discussable.
Want to hear your opinions @mitsuhiko @littledan  @jkup 