### PR TITLE
lowercase sourcemap header

### DIFF
--- a/source-map.bs
+++ b/source-map.bs
@@ -342,11 +342,11 @@ support in order to add an HTTP header and the second requires an annotation in 
 The HTTP header should supply the source map URL reference as:
  
 ```
-SourceMap: <url>
+sourcemap: <url>
 ```
 
-Note: Previous revisions of this document recommended a header name of `X-SourceMap`.  This
-is now deprecated; `SourceMap` is now expected.
+Note: Previous revisions of this document recommended a header name of `x-sourcemap`.  This
+is now deprecated; `sourcemap` is now expected.
 
 The generated code should include a line at the end of the source, with the following form:
 


### PR DESCRIPTION
This lowercases the source map header in the specification. This is not a specification change as HTTP headers are already case insensitive. However it might resolve potential issues in the future as not all implementers might correctly handle the case insensitive nature.

HTTP2 and later demand lowercase headers as the canonical format